### PR TITLE
Rename to `publish` on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def _read(filename):
 
 def main():
     setup(
-        name="fiaas-publish",
+        name="publish",
         author="FiaaS developers",
         author_email="fiaas@googlegroups.com",
         use_scm_version=True,


### PR DESCRIPTION
We have been given ownership of `publish` on PyPI, as we originally wanted. I think this is the only change needed to publish the project under the new name.