### PR TITLE
Explain more about why a repo is deemed unfit for release

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -82,11 +82,23 @@ class Repository(object):
         """
         if self._force:
             return True
-        if self.repo.is_dirty() or self.repo.untracked_files or not self.current_tag:
+        if self.repo.is_dirty():
+            print("Repository is dirty", file=sys.stderr)
+            return False
+        if self.repo.untracked_files:
+            file_list = "\n\t".join(self.repo.untracked_files)
+            print("Repository has untracked files:\n\t{}".format(file_list), file=sys.stderr)
+            return False
+        if not self.current_tag:
+            print("No tag found")
             return False
         try:
-            return self.RELEASE_TAG_PATTERN.match(self.current_tag.tag) is not None
+            valid_tag = self.RELEASE_TAG_PATTERN.match(self.current_tag.tag) is not None
+            if not valid_tag:
+                print("Tag {} is not a valid release tag".format(self.current_tag.tag))
+            return valid_tag
         except AttributeError:
+            print("Unable to read tag name")
             return False
 
     def generate_changelog(self):


### PR DESCRIPTION
I tried releasing v0.3.0, but publish descided the repo was not ready for release. Trying locally on the same commit considers the repo ready. This change will make it clearer *why* the repo is not ready for release, so that we can change our pipeline to avoid the problem.
