### PR TITLE
Ignore .pip_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.pip_cache/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
`.pip_cache` is created inside the repo when building on Semaphore, and that makes `publish` not want to publish a new version.