### PR TITLE
Use correct regex for matching tags for auto-promotion

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,4 +38,4 @@ promotions:
     auto_promote_on:
       - result: passed
         branch:
-          - ^refs/tags/v.*rc\d+$
+          - ^refs/tags/v\d+\.\d+\.\d+$


### PR DESCRIPTION
I failed to spot exactly what the "trick" to promote on tag did, so the pattern was wrong. This pattern should match the tags we normally use for releases, and should mean we get auto-promotion whenever we push a tag.

Change is trivial, so I'm going to merge this so I can test it and also get a release of the tool out.