### PR TITLE
Pin the version of attrs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ TESTS_REQ = [
     'pytest-cov==2.6.0',
     'pytest-html==1.19.0',
     'pytest-sugar==0.9.2',
+    'attrs==19.1.0',  # Pin this to avoid problems caused by https://github.com/python-attrs/attrs/issues/307
+                      # TODO: Proper fix is to upgrade to pytest>5.2.0, but that drops Python 2 support
 ]
 
 


### PR DESCRIPTION
Latest version of attrs changes a keyword parameter, causing a TypeError in pytest.
The problem is fixed in pytest 5.2.0, but since pytest 5 drops Python 2 support,
we just do this for now.