### PR TITLE
Pin prospector and virtualenv to versions which work for python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ GENERIC_REQ = [
 ]
 
 CODE_QUALITY_REQ = [
-    'prospector',
+    'prospector==1.2.0',
 ]
 
 TESTS_REQ = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = py27,py35,py36,py37
 skip_missing_interpreters=True
+requires=
+  py27: virtualenv>=16.7.12
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
-  Force a recent enough virtualenv version. This fixes an issue where the tox environment, which is created with virtualenv, gets a too old version of setuptools. Some older versions of setuptools will install packages which are incompatible with python2, so this should avoid python2 builds failing because of incompatible dependencies being installed.
- Use most recent prospector with python2 support

