### PR TITLE
Always use more recent virtualenv with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27,py35,py36,py37
 skip_missing_interpreters=True
 requires=
-  py27: virtualenv>=16.7.12
+  virtualenv>=16.7.12
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
It seems tox doesn't support configuring global options (such as requires) with factors. For some reason this works on python2 but on python3 tox raises an exception. Remove py27 factor and always require more recent `virtualenv` version

follow up from #18 