### PR TITLE
Remove python 2 support, upgrade dependencies

### DIFF
--- a/.semaphore/make-release.yml
+++ b/.semaphore/make-release.yml
@@ -30,11 +30,12 @@ blocks:
           value: .pip_cache
       prologue:
         commands:
+          - sem-version python 3.9
           - export PATH="${HOME}/.local/bin":"${PATH}"
           - checkout
           - mkdir "${PIP_CACHE_DIR}"
           - cache restore "setup-${SEMAPHORE_GIT_BRANCH}-$(checksum setup.py)","setup-${SEMAPHORE_GIT_BRANCH}",setup-master
-          - pip install --user .
+          - pip install .
       jobs:
         - name: Publish
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,7 +44,7 @@ blocks:
               values: ["py39"]
         - name: Gather coverage data
           commands:
-            - tox -e coverage
+            - CODACY_PROJECT_TOKEN=$CODACY_PUBLISH_API_TOKEN tox -e coverage
       epilogue:
         commands:
           - cache store "setup-${SEMAPHORE_GIT_BRANCH}-$(checksum setup.py)" "${PIP_CACHE_DIR}"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,7 +23,7 @@ blocks:
   - name: Run tests
     task:
       secrets:
-        - name: publish-codacy-token
+        - name: codacy_api_token
       env_vars:
         - name: PIP_CACHE_DIR
           value: .pip_cache

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -29,18 +29,19 @@ blocks:
           value: .pip_cache
       prologue:
         commands:
+          - sem-version python 3.9
           - export PATH="${HOME}/.local/bin":"${PATH}"
           - checkout
           - mkdir "${PIP_CACHE_DIR}"
           - cache restore "setup-${SEMAPHORE_GIT_BRANCH}-$(checksum setup.py)","setup-${SEMAPHORE_GIT_BRANCH}",setup-master
-          - pip install --user tox
+          - pip install tox
       jobs:
         - name: Tests
           commands:
             - tox
           matrix:
             - env_var: TOXENV
-              values: ["py27", "py35", "py36", "py37"]
+              values: ["py39"]
         - name: Gather coverage data
           commands:
             - tox -e coverage

--- a/publish.py
+++ b/publish.py
@@ -40,7 +40,6 @@ import subprocess
 import sys
 import tempfile
 
-import six
 from git import Repo, BadName, GitCommandError
 from git.cmd import Git
 from github_release import gh_release_create
@@ -209,12 +208,8 @@ def create_artifacts(changelog, options):
     """
     fd, name = tempfile.mkstemp(prefix="changelog", suffix=".rst", text=True)
     formatted_changelog = format_rst_changelog(changelog, options)
-    if six.PY2:
-        with os.fdopen(fd, "w") as fobj:
-            fobj.write(formatted_changelog.encode("utf-8"))
-    else:
-        with open(fd, "w", encoding="utf-8") as fobj:
-            fobj.write(formatted_changelog)
+    with open(fd, "w", encoding="utf-8") as fobj:
+        fobj.write(formatted_changelog)
     subprocess.check_call([
         sys.executable, "setup.py",
         "egg_info", "--tag-build=",

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,9 @@ import os
 from setuptools import setup
 
 GENERIC_REQ = [
-    'GitPython==2.1.11',
+    'GitPython==3.1.41',
     "twine==1.12.1",
     "githubrelease==1.5.8",
-    "gitdb2>=2.0.0,<3.0.0",  # Pin this to avoid a problem with changed API.
-                             # TODO: Should update to latest GitPython to fix.
 ]
 
 CODE_QUALITY_REQ = [

--- a/setup.py
+++ b/setup.py
@@ -26,17 +26,15 @@ GENERIC_REQ = [
 ]
 
 CODE_QUALITY_REQ = [
-    'prospector==1.2.0',
+    'prospector==1.10.3',
 ]
 
 TESTS_REQ = [
-    'tox==3.6.1',
-    'pytest==4.0.2',
-    'pytest-cov==2.6.0',
-    'pytest-html==1.19.0',
-    'pytest-sugar==0.9.2',
-    'attrs==19.1.0',  # Pin this to avoid problems caused by https://github.com/python-attrs/attrs/issues/307
-                      # TODO: Proper fix is to upgrade to pytest>5.2.0, but that drops Python 2 support
+    'tox==4.12.0',
+    'pytest==7.4.4',
+    'pytest-cov==4.1.0',
+    'pytest-html==4.1.1',
+    'pytest-sugar==0.9.7',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ import os
 from setuptools import setup
 
 GENERIC_REQ = [
-    "six==1.12.0",
     'GitPython==2.1.11',
     "twine==1.12.1",
     "githubrelease==1.5.8",
@@ -34,7 +33,6 @@ CODE_QUALITY_REQ = [
 
 TESTS_REQ = [
     'tox==3.6.1',
-    'mock==2.0.0',
     'pytest==4.0.2',
     'pytest-cov==2.6.0',
     'pytest-html==1.19.0',
@@ -95,12 +93,8 @@ def main():
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: OS Independent",
             "Programming Language :: Python",
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.9",
             "Topic :: Internet",
             "Topic :: Software Development :: Build Tools",
             "Topic :: System :: Software Distribution",

--- a/test_publish.py
+++ b/test_publish.py
@@ -1,12 +1,12 @@
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@ from __future__ import unicode_literals
 
 import argparse
 
-import mock
+from unittest import mock
 import pytest
 from git import Repo, TagObject, Commit, GitCommandError
 from git.util import hex_to_bin

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37
+envlist = py39
 skip_missing_interpreters=True
 requires=
   virtualenv>=16.7.12


### PR DESCRIPTION
- Use python 3.9
- Upgrade GitPython to most recent version
- Upgrade pytest and related dependencies to most recent versions
- Upgrade prospector dependency