### PR TITLE
Upgrade twine, githubrelease

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ from setuptools import setup
 
 GENERIC_REQ = [
     'GitPython==3.1.41',
-    "twine==1.12.1",
-    "githubrelease==1.5.8",
+    "twine==4.0.2",
+    "githubrelease==1.5.9",
 ]
 
 CODE_QUALITY_REQ = [


### PR DESCRIPTION
* The most recent version of githubrelease adds retries when getting the reference to the newly created release, avoiding an error on release creation.

* Upgrade twine to the most recent version to avoid an apparent transitive dependency issue with a newer version of requests-toolbelt.