### PR TITLE
Fix, simplify, and improve certain aspects of the project.

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -215,7 +215,7 @@ def main():
     parser.add_argument("repository", help="The name of the repository on GitHub and PyPi")
     options = parser.parse_args()
     if not "GITHUB_TOKEN" in os.environ:
-        print("This command requires the GITHUB_TOKEN environment variable to be set. Before you run this command, try `export GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Unix-likes) or `set GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Windows)")
+        print("Publish requires the GITHUB_TOKEN environment variable to be set. Before you run this command, try `export GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Unix-likes) or `set GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Windows)\n\nPublish also requires the TWINE_USERNAME and TWINE_PASSWORD environment variables to be set in the same way; but, unlike GITHUB_TOKEN, you will be prompted to provide them later if they aren't in the environment, so setting them beforehand is not mandatory.")
         sys.exit(3)
     sys.exit(publish(options))
 

--- a/publish.py
+++ b/publish.py
@@ -40,7 +40,7 @@ import subprocess
 import sys
 import tempfile
 
-from git import Repo, BadName, GitCommandError
+from git import Repo, GitCommandError
 from git.cmd import Git
 from github_release import gh_release_create
 
@@ -211,7 +211,7 @@ def main():
     parser.add_argument("organization", help="Github organization")
     parser.add_argument("repository", help="The name of the repository on GitHub and PyPi")
     options = parser.parse_args()
-    if not "GITHUB_TOKEN" in os.environ:
+    if "GITHUB_TOKEN" not in os.environ:
         print("Publish requires the GITHUB_TOKEN environment variable to be set. Before you run this command, try `export GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Unix-likes) or `set GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Windows)\n\nPublish also requires the TWINE_USERNAME and TWINE_PASSWORD environment variables to be set in the same way; but, unlike GITHUB_TOKEN, you will be prompted to provide them later if they aren't in the environment, so setting them beforehand is not mandatory.")
         sys.exit(3)
     sys.exit(publish(options))

--- a/publish.py
+++ b/publish.py
@@ -209,7 +209,7 @@ def main():
     parser.add_argument("-f", "--force", action="store_true", help="Make a release even if the repo is unclean")
     parser.add_argument("-n", "--dry-run", action="store_true", help="Do everything, except upload to GH/PyPI")
     parser.add_argument("organization", help="Github organization")
-    parser.add_argument("repository", help="The name of the repository on GitHub and PyPi")
+    parser.add_argument("repository", help="The name of the repository on GitHub")
     options = parser.parse_args()
     if "GITHUB_TOKEN" not in os.environ:
         print("Publish requires the GITHUB_TOKEN environment variable to be set. Before you run this command, try `export GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Unix-likes) or `set GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Windows)\n\nPublish also requires the TWINE_USERNAME and TWINE_PASSWORD environment variables to be set in the same way; but, unlike GITHUB_TOKEN, you will be prompted to provide them later if they aren't in the environment, so setting them beforehand is not mandatory.")

--- a/publish.py
+++ b/publish.py
@@ -89,7 +89,7 @@ class Repository(object):
             return False
         tag_is_valid = self.RELEASE_TAG_PATTERN.match(self.current_tag) is not None
         if not tag_is_valid:
-            print("Tag {} is not a valid release tag. (Expected v<major>.<minor>.<bugfix> (with numbers).)".format(self.current_tag))
+            print("Tag \"{}\" is not a valid release tag. Expected \"vX.Y.Z\" where X, Y, and Z are non-negative integers.".format(self.current_tag), file=sys.stderr)
         return tag_is_valid
 
     def generate_changelog(self):
@@ -215,7 +215,7 @@ def main():
     parser.add_argument("repository", help="The name of the repository on GitHub and PyPi")
     options = parser.parse_args()
     if not "GITHUB_TOKEN" in os.environ:
-        print("This command requires the GITHUB_TOKEN environment variable to be set. Before you run this command, try `export GITHUB_TOKEN=gh-token` (on Unix-likes) or `set GITHUB_TOKEN=gh-token` (on Windows)")
+        print("This command requires the GITHUB_TOKEN environment variable to be set. Before you run this command, try `export GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Unix-likes) or `set GITHUB_TOKEN=your-gh-token-blah-blah-blah-whatever` (on Windows)")
         sys.exit(3)
     sys.exit(publish(options))
 

--- a/publish.py
+++ b/publish.py
@@ -67,18 +67,10 @@ class Repository(object):
     def __init__(self, options):
         self.repo = Repo(options.directory)
         self._force = options.force
-        self._current_tag = None
-
-    @property
-    def current_tag(self):
-        if self._current_tag:
-            return self._current_tag
-        try:
-            current_name = self.repo.git.describe(all=True)
-            self._current_tag = self.repo.rev_parse(current_name)
-            return self._current_tag
-        except (BadName, GitCommandError):
-            return None
+        current_name = self.repo.git.describe(all=True)
+        print(current_name)
+        self.current_tag = self.repo.rev_parse(current_name)
+        print(self.current_tag)
 
     @property
     def version(self):

--- a/publish.py
+++ b/publish.py
@@ -62,7 +62,7 @@ class Formatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsH
 
 
 class Repository(object):
-    RELEASE_TAG_PATTERN = re.compile(r"^v\d+(\.\d+){0,2}$")
+    RELEASE_TAG_PATTERN = re.compile(r"^v(0|[1-9]\d*)(\.(0|[1-9]\d*)){0,2}$")
 
     def __init__(self, options):
         self.repo = Repo(options.directory)
@@ -89,7 +89,7 @@ class Repository(object):
             return False
         tag_is_valid = self.RELEASE_TAG_PATTERN.match(self.current_tag) is not None
         if not tag_is_valid:
-            print("Tag \"{}\" is not a valid release tag. Expected \"vX.Y.Z\" where X, Y, and Z are non-negative integers.".format(self.current_tag), file=sys.stderr)
+            print("Tag \"{}\" is not a valid release tag. Expected \"vX.Y.Z\" where X, Y, and Z are non-negative integers, formatted without leading zeros.".format(self.current_tag), file=sys.stderr)
         return tag_is_valid
 
     def generate_changelog(self):

--- a/publish.py
+++ b/publish.py
@@ -69,7 +69,7 @@ class Repository(object):
         current_name = self.repo.git.describe(all=True)
         print(f"Current name: {current_name}", file=sys.stderr)
         current_tag = self.repo.rev_parse(current_name)
-        print(f"Current tag (long): {current_tag}", file=sys.stderr)
+        print(f"Current tag id: {current_tag}", file=sys.stderr)
         try:
           self.current_tag = current_tag.tag
           print(f"Current tag: {self.current_tag}", file=sys.stderr)

--- a/publish.py
+++ b/publish.py
@@ -137,7 +137,7 @@ class Uploader(object):
 
     def pypi_release(self):
         """Create release in pypi.python.org, and upload artifacts and changelog"""
-        self._call("twine", "upload", *self.artifacts, msg="Failed to upload artifacts to PyPI")
+        self._call("twine", "upload", "--skip-existing", *self.artifacts, msg="Failed to upload artifacts to PyPI")
 
 
 def format_rst_changelog(changelog, options):

--- a/publish.py
+++ b/publish.py
@@ -68,7 +68,7 @@ class Repository(object):
         self.repo = Repo(options.directory)
         self._force = options.force
         self.current_tag = self.repo.git.describe(all=True).split('/')[1]
-        print(self.current_tag)
+        print(f"Current tag: {self.current_tag}", file=sys.stderr)
 
     def ready_for_release(self):
         """Return true if the current git checkout is suitable for release
@@ -89,7 +89,7 @@ class Repository(object):
             return False
         tag_is_valid = self.RELEASE_TAG_PATTERN.match(self.current_tag) is not None
         if not tag_is_valid:
-            print("Tag {} is not a valid release tag".format(self.current_tag))
+            print("Tag {} is not a valid release tag. (Expected v<major>.<minor>.<bugfix> (with numbers).)".format(self.current_tag))
         return tag_is_valid
 
     def generate_changelog(self):
@@ -212,8 +212,11 @@ def main():
     parser.add_argument("-f", "--force", action="store_true", help="Make a release even if the repo is unclean")
     parser.add_argument("-n", "--dry-run", action="store_true", help="Do everything, except upload to GH/PyPI")
     parser.add_argument("organization", help="Github organization")
-    parser.add_argument("repository", help="The repository")
+    parser.add_argument("repository", help="The name of the repository on GitHub and PyPi")
     options = parser.parse_args()
+    if not "GITHUB_TOKEN" in os.environ:
+        print("This command requires the GITHUB_TOKEN environment variable to be set. Before you run this command, try `export GITHUB_TOKEN=gh-token` (on Unix-likes) or `set GITHUB_TOKEN=gh-token` (on Windows)")
+        sys.exit(3)
     sys.exit(publish(options))
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 
 GENERIC_REQ = [
     'GitPython==3.1.41',
-    "twine==4.0.2",
+    "twine==5.1.1",
     "githubrelease==1.5.9",
 ]
 


### PR DESCRIPTION
Recently, I began to use Publish for myself, as it sort of matches my workflow. While trying it out, I encountered several errors and edge cases, which I have now fixed. Here is an abridged listing of my changes:
* Don't do the tag.tag dance. The tag is always the tag. This might break compatibility with some other system, but it fixes compatibility on mine.
* Assert the existence of GITHUB_TOKEN upfront, because without it we just crash later.
* Simplify some code.
* Enforce semver prohibition on leading zeros in regex.
* Bump the required version of Twine to avoid a KeyError.
* Force now only forces through dirty, not tags; thus matching its help message.
* Print out a couple more diagnostics, and use stderr for more of them, under an internal logic I cannot explicitly justify, but which seems sort of right.
* General reformatting.