### PR TITLE
Upgrade twine to 5.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 
 GENERIC_REQ = [
     'GitPython==3.1.41',
-    "twine==4.0.2",
+    "twine==5.1.1",
     "githubrelease==1.5.9",
 ]
 


### PR DESCRIPTION
The pinned version of twine appears to be incompatible with the version of importlib-metadata it pulls in transitively; https://github.com/pypa/twine/issues/977
Upgrade twine to 5.1.1 where this issue should be fixed.